### PR TITLE
Use `bash` shell for activation/deactivation scripts

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -11,7 +11,7 @@ jobs:
       linux_64_:
         CONFIG: linux_64_
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
   timeoutInMinutes: 360
 
   steps:

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -5,7 +5,4 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- quay.io/condaforge/linux-anvil-comp7
-zip_keys:
-- - cdt_name
-  - docker_image
+- quay.io/condaforge/linux-anvil-cos7-x86_64

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -5,6 +5,8 @@
 # changes to this script, consider a proposal to conda-smithy so that other feedstocks can also
 # benefit from the improvement.
 
+# -*- mode: jinja-shell -*-
+
 set -xeuo pipefail
 export FEEDSTOCK_ROOT="${FEEDSTOCK_ROOT:-/home/conda/feedstock_root}"
 source ${FEEDSTOCK_ROOT}/.scripts/logging_utils.sh
@@ -25,10 +27,10 @@ conda-build:
  root-dir: ${FEEDSTOCK_ROOT}/build_artifacts
 
 CONDARC
-GET_BOA=boa
-BUILD_CMD=mambabuild
 
-conda install --yes --quiet "conda-forge-ci-setup=3" conda-build pip ${GET_BOA:-} -c conda-forge
+
+mamba install --update-specs --yes --quiet "conda-forge-ci-setup=3" conda-build pip boa -c conda-forge
+mamba update --update-specs --yes --quiet "conda-forge-ci-setup=3" conda-build pip boa -c conda-forge
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
@@ -53,7 +55,7 @@ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     # Drop into an interactive shell
     /bin/bash
 else
-    conda $BUILD_CMD "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+    conda mambabuild "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
     ( startgroup "Validating outputs" ) 2> /dev/null

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
 BSD 3-clause license
-Copyright (c) 2015-2021, conda-forge contributors
+Copyright (c) 2015-2022, conda-forge contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/recipe/activate.sh
+++ b/recipe/activate.sh
@@ -1,9 +1,15 @@
+#!/bin/bash
 # This activates fzf-based fuzzy finding for happi searches.
 # This is meant to be sourced from bash.
 
+if [ "${SHELL}" != "bash" ]; then
+    echo -e "Only bash shell is supported. Used shell: ${SHELL}"
+    exit 1
+fi
+
 _fzf_complete_happi() {
   _fzf_complete --multi --reverse --prompt="happi> " -- "$@" < <(
-    python `which happi` search '*' --json 2>/dev/null |python -c '
+    python `which happi` search '*' --json 2>/dev/null | python -c '
 import json
 import sys
 items = json.load(sys.stdin)

--- a/recipe/activate.sh
+++ b/recipe/activate.sh
@@ -2,11 +2,11 @@
 # This activates fzf-based fuzzy finding for happi searches.
 # This is meant to be sourced from bash.
 
-if [[ "${SHELL}" =~ .*"bash" ]]; then
+if [[ "${BASH}" =~ .*"bash" ]]; then
     # Do nothing
     :
 else
-    echo "Only bash shell is supported. Used shell: ${SHELL}"
+    echo "Only bash shell is supported. Used shell: ${BASH}"
     exit 1
 fi
 

--- a/recipe/activate.sh
+++ b/recipe/activate.sh
@@ -2,8 +2,11 @@
 # This activates fzf-based fuzzy finding for happi searches.
 # This is meant to be sourced from bash.
 
-if [ "${SHELL}" != "bash" ]; then
-    echo -e "Only bash shell is supported. Used shell: ${SHELL}"
+if [[ "${SHELL}" =~ .*"bash" ]]; then
+    # Do nothing
+    :
+else
+    echo "Only bash shell is supported. Used shell: ${SHELL}"
     exit 1
 fi
 

--- a/recipe/activate.sh
+++ b/recipe/activate.sh
@@ -6,8 +6,8 @@ if [[ "${BASH}" =~ .*"bash" ]]; then
     # Do nothing
     :
 else
-    echo "Only bash shell is supported. Used shell: ${BASH}"
-    exit 1
+    echo "'happi' activation: only bash shell is supported. Used shell: ${BASH}"
+    return
 fi
 
 _fzf_complete_happi() {

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,4 +1,6 @@
-$PYTHON setup.py install --single-version-externally-managed --record=record.txt
+#!/bin/bash
+
+$PYTHON -m pip install --no-deps -vv
 
 mkdir -p $PREFIX/etc/conda/activate.d
 mkdir -p $PREFIX/etc/conda/deactivate.d

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-$PYTHON -m pip install --no-deps -vv
+$PYTHON -m pip install . --no-deps -vv
 
 mkdir -p $PREFIX/etc/conda/activate.d
 mkdir -p $PREFIX/etc/conda/deactivate.d

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -8,8 +8,9 @@ mkdir -p $PREFIX/etc/conda/deactivate.d
 ACTIVATE=$PREFIX/etc/conda/activate.d/happi
 DEACTIVATE=$PREFIX/etc/conda/deactivate.d/happi
 
-cp -f conda-recipe/activate.sh ${ACTIVATE}.sh
-cp -f conda-recipe/deactivate.sh ${DEACTIVATE}.sh
+# From https://docs.conda.io/projects/conda-build/en/latest/user-guide/environment-variables.html
+cp -f ${RECIPE_DIR}/activate.sh ${ACTIVATE}.sh
+cp -f ${RECIPE_DIR}/deactivate.sh ${DEACTIVATE}.sh
 
 unset ACTIVATE
 unset DEACTIVATE

--- a/recipe/deactivate.sh
+++ b/recipe/deactivate.sh
@@ -6,8 +6,8 @@ if [[ "${BASH}" =~ .*"bash" ]]; then
     # Do nothing
     :
 else
-    echo "Only bash shell is supported. Used shell: ${BASH}"
-    exit 1
+    echo "'happi' deactivation: only bash shell is supported. Used shell: ${BASH}"
+    return
 fi
 
 [ -n "$BASH" ] && complete -r happi

--- a/recipe/deactivate.sh
+++ b/recipe/deactivate.sh
@@ -1,5 +1,11 @@
+#!/bin/bash
 # This deactivates fzf-based fuzzy finding for happi searches.
 # This is meant to be sourced from bash.
+
+if [ "${SHELL}" != "bash" ]; then
+    echo -e "Only bash shell is supported. Used shell: ${SHELL}"
+    exit 1
+fi
 
 [ -n "$BASH" ] && complete -r happi
 

--- a/recipe/deactivate.sh
+++ b/recipe/deactivate.sh
@@ -2,8 +2,11 @@
 # This deactivates fzf-based fuzzy finding for happi searches.
 # This is meant to be sourced from bash.
 
-if [ "${SHELL}" != "bash" ]; then
-    echo -e "Only bash shell is supported. Used shell: ${SHELL}"
+if [[ "${SHELL}" =~ .*"bash" ]]; then
+    # Do nothing
+    :
+else
+    echo "Only bash shell is supported. Used shell: ${SHELL}"
     exit 1
 fi
 

--- a/recipe/deactivate.sh
+++ b/recipe/deactivate.sh
@@ -2,11 +2,11 @@
 # This deactivates fzf-based fuzzy finding for happi searches.
 # This is meant to be sourced from bash.
 
-if [[ "${SHELL}" =~ .*"bash" ]]; then
+if [[ "${BASH}" =~ .*"bash" ]]; then
     # Do nothing
     :
 else
-    echo "Only bash shell is supported. Used shell: ${SHELL}"
+    echo "Only bash shell is supported. Used shell: ${BASH}"
     exit 1
 fi
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/pcdshub/{{ name }}/archive/v{{ version }}.tar.gz
-  sha256: 7240d9fb11719e6df01f9359f538d3e9ebc558258f3fe7cdbf5ff638568a0a32
+  sha256: 14b0173019cf066f15aff92e462762a71ba9be13dfc1cb70548195907a76115d
 
 build:
   noarch: python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   entry_points:
     - happi = happi.cli:main
 


### PR DESCRIPTION
As discussed on Nikea slack, here is an update to explicitly use bash shell for the activation/deactivation scripts and add some guards.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
